### PR TITLE
Simplify findActionBool logic

### DIFF
--- a/Ding.xm
+++ b/Ding.xm
@@ -23,11 +23,7 @@ BOOL findActionBool(int position) {
 	// 0 = Muted
 	// 1 = Unmuted
 
-	if (actionMute) {
-		return (position == 0) ? YES : NO;
-	} else {
-		return (position == 0) ? NO : YES;
-	}
+	return (position == 0) == actionMute;
 }
 
 %group CallGroup


### PR DESCRIPTION
Simplified the findActionBool function logic.
Wrote some quick tests and all of the results match the original implementation.